### PR TITLE
 Fix to compile against openssl-1.1.1

### DIFF
--- a/tools/gcttool/main.c
+++ b/tools/gcttool/main.c
@@ -157,8 +157,7 @@ int main(int argc, char **argv) {
 
 #ifdef HAVE_OPENSSL
   /* for conversion purposes */
-  SSL_load_error_strings();
-  SSL_library_init();
+  OPENSSL_init_ssl(0, NULL);
   GWEN_Gui_SetKeyDataFromTextOpenSslFn(gui, getKeyDataFromTextOpenSSL);
 #endif
 


### PR DESCRIPTION
 Fix to compile against openssl-1.1.1
- SSL_library_init
see https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-pre8/include/openssl/ssl.h#L1921-L1923
- SSL_load_error_strings
see https://github.com/openssl/openssl/blob/c5d1fb78fd0fdbe1f1e61211bd56192a0f95bc91/include/openssl/ssl.h#L1583-L1587