### PR TITLE
Remove unused variables in gui/gtk3.

### DIFF
--- a/gui/gtk3/gtk3_gui_dialog.c
+++ b/gui/gtk3/gtk3_gui_dialog.c
@@ -533,12 +533,10 @@ int Gtk3Gui_GetRawText(const char *text, GWEN_BUFFER *tbuf) {
 
   if (p && p2) {
     int startPos;
-    int endPos;
 
     p2+=7; /* skip "</html>" */
 
     startPos=(p-text);
-    endPos=(p2-text);
 
     /* append stuff before startPos */
     if (startPos)

--- a/gui/gtk3/w_checkbox.c
+++ b/gui/gtk3/w_checkbox.c
@@ -162,11 +162,8 @@ static void Gtk3Gui_WCheckBox_Toggled_handler(GtkButton *button, gpointer data) 
 int Gtk3Gui_WCheckBox_Setup(GWEN_WIDGET *w) {
   GtkWidget *g;
   const char *s;
-  uint32_t flags;
   GWEN_WIDGET *wParent;
-  gulong toggled_handler_id;
 
-  flags=GWEN_Widget_GetFlags(w);
   wParent=GWEN_Widget_Tree_GetParent(w);
   s=GWEN_Widget_GetText(w, 0);
 
@@ -184,10 +181,10 @@ int Gtk3Gui_WCheckBox_Setup(GWEN_WIDGET *w) {
   GWEN_Widget_SetSetCharPropertyFn(w, Gtk3Gui_WCheckBox_SetCharProperty);
   GWEN_Widget_SetGetCharPropertyFn(w, Gtk3Gui_WCheckBox_GetCharProperty);
 
-  toggled_handler_id=g_signal_connect(g,
-                                      "toggled",
-                                      G_CALLBACK (Gtk3Gui_WCheckBox_Toggled_handler),
-                                      w);
+  g_signal_connect(g,
+                   "toggled",
+                   G_CALLBACK (Gtk3Gui_WCheckBox_Toggled_handler),
+                   w);
 
   if (wParent)
     GWEN_Widget_AddChildGuiWidget(wParent, w);

--- a/gui/gtk3/w_combobox.c
+++ b/gui/gtk3/w_combobox.c
@@ -250,7 +250,6 @@ int Gtk3Gui_WComboBox_Setup(GWEN_WIDGET *w) {
   GtkListStore *store;
   uint32_t flags;
   GWEN_WIDGET *wParent;
-  gulong changed_handler_id;
 
   flags=GWEN_Widget_GetFlags(w);
   wParent=GWEN_Widget_Tree_GetParent(w);
@@ -283,10 +282,10 @@ int Gtk3Gui_WComboBox_Setup(GWEN_WIDGET *w) {
   GWEN_Widget_SetSetCharPropertyFn(w, Gtk3Gui_WComboBox_SetCharProperty);
   GWEN_Widget_SetGetCharPropertyFn(w, Gtk3Gui_WComboBox_GetCharProperty);
 
-  changed_handler_id=g_signal_connect(g,
-                                      "changed",
-                                      G_CALLBACK (changed_handler),
-                                      w);
+  g_signal_connect(g,
+                   "changed",
+                   G_CALLBACK (changed_handler),
+                   w);
 
   if (wParent)
     GWEN_Widget_AddChildGuiWidget(wParent, w);

--- a/gui/gtk3/w_dialog.c
+++ b/gui/gtk3/w_dialog.c
@@ -177,9 +177,7 @@ int Gtk3Gui_WDialog_AddChildGuiWidget(GWEN_WIDGET *w, GWEN_WIDGET *wChild) {
 int Gtk3Gui_WDialog_Setup(GWEN_WIDGET *w) {
   GtkWidget *g;
   const char *s;
-  uint32_t flags;
 
-  flags=GWEN_Widget_GetFlags(w);
   s=GWEN_Widget_GetText(w, 0);
 
   g=gtk_window_new(GTK_WINDOW_TOPLEVEL);

--- a/gui/gtk3/w_gridlayout.c
+++ b/gui/gtk3/w_gridlayout.c
@@ -128,7 +128,6 @@ int Gtk3Gui_WGridLayout_AddChildGuiWidget(GWEN_WIDGET *w, GWEN_WIDGET *wChild) {
   GTK3_GRIDLAYOUT_WIDGET *xw;
   GtkWidget *g;
   GtkWidget *gChild;
-  uint32_t cflags;
   int x;
   int y;
 
@@ -136,7 +135,6 @@ int Gtk3Gui_WGridLayout_AddChildGuiWidget(GWEN_WIDGET *w, GWEN_WIDGET *wChild) {
   xw=GWEN_INHERIT_GETDATA(GWEN_WIDGET, GTK3_GRIDLAYOUT_WIDGET, w);
   assert(xw);
 
-  cflags=GWEN_Widget_GetFlags(wChild);
 
   g=GTK_WIDGET(GWEN_Widget_GetImplData(w, GTK3_DIALOG_WIDGET_REAL));
   assert(g);
@@ -194,7 +192,6 @@ void Gtk3Gui_WGridLayout_FreeData(void *bp, void *p) {
 
 int Gtk3Gui_WGridLayout_Setup(GWEN_WIDGET *w) {
   GtkWidget *g;
-  uint32_t flags;
   GWEN_WIDGET *wParent;
   GTK3_GRIDLAYOUT_WIDGET *xw;
   int rows;
@@ -203,7 +200,6 @@ int Gtk3Gui_WGridLayout_Setup(GWEN_WIDGET *w) {
   GWEN_NEW_OBJECT(GTK3_GRIDLAYOUT_WIDGET, xw);
   GWEN_INHERIT_SETDATA(GWEN_WIDGET, GTK3_GRIDLAYOUT_WIDGET, w, xw, Gtk3Gui_WGridLayout_FreeData);
 
-  flags=GWEN_Widget_GetFlags(w);
   wParent=GWEN_Widget_Tree_GetParent(w);
   cols=GWEN_Widget_GetColumns(w);
   rows=GWEN_Widget_GetRows(w);

--- a/gui/gtk3/w_groupbox.c
+++ b/gui/gtk3/w_groupbox.c
@@ -171,10 +171,8 @@ int Gtk3Gui_WGroupBox_Setup(GWEN_WIDGET *w) {
   GtkWidget *g;
   GtkWidget *gContent;
   const char *s;
-  uint32_t flags;
   GWEN_WIDGET *wParent;
 
-  flags=GWEN_Widget_GetFlags(w);
   wParent=GWEN_Widget_Tree_GetParent(w);
   s=GWEN_Widget_GetText(w, 0);
 

--- a/gui/gtk3/w_hlayout.c
+++ b/gui/gtk3/w_hlayout.c
@@ -137,10 +137,8 @@ int Gtk3Gui_WHLayout_AddChildGuiWidget(GWEN_WIDGET *w, GWEN_WIDGET *wChild) {
 
 int Gtk3Gui_WHLayout_Setup(GWEN_WIDGET *w) {
   GtkWidget *g;
-  uint32_t flags;
   GWEN_WIDGET *wParent;
 
-  flags=GWEN_Widget_GetFlags(w);
   wParent=GWEN_Widget_Tree_GetParent(w);
 
   g=gtk_box_new(GTK_ORIENTATION_HORIZONTAL,

--- a/gui/gtk3/w_hline.c
+++ b/gui/gtk3/w_hline.c
@@ -76,10 +76,8 @@ int Gtk3Gui_WHLine_GetIntProperty(GWEN_WIDGET *w,
 
 int Gtk3Gui_WHLine_Setup(GWEN_WIDGET *w) {
   GtkWidget *g;
-  uint32_t flags;
   GWEN_WIDGET *wParent;
 
-  flags=GWEN_Widget_GetFlags(w);
   wParent=GWEN_Widget_Tree_GetParent(w);
 
   g=gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);

--- a/gui/gtk3/w_hspacer.c
+++ b/gui/gtk3/w_hspacer.c
@@ -76,10 +76,8 @@ int Gtk3Gui_WHSpacer_GetIntProperty(GWEN_WIDGET *w,
 
 int Gtk3Gui_WHSpacer_Setup(GWEN_WIDGET *w) {
   GtkWidget *g;
-  uint32_t flags;
   GWEN_WIDGET *wParent;
 
-  flags=GWEN_Widget_GetFlags(w);
   wParent=GWEN_Widget_Tree_GetParent(w);
 
   g=gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);

--- a/gui/gtk3/w_label.c
+++ b/gui/gtk3/w_label.c
@@ -146,11 +146,9 @@ const char* Gtk3Gui_WLabel_GetCharProperty(GWEN_WIDGET *w,
 int Gtk3Gui_WLabel_Setup(GWEN_WIDGET *w) {
   GtkWidget *g;
   const char *s;
-  uint32_t flags;
   GWEN_WIDGET *wParent;
   GWEN_BUFFER *tbuf;
 
-  flags=GWEN_Widget_GetFlags(w);
   wParent=GWEN_Widget_Tree_GetParent(w);
   s=GWEN_Widget_GetText(w, 0);
 

--- a/gui/gtk3/w_lineedit.c
+++ b/gui/gtk3/w_lineedit.c
@@ -183,8 +183,6 @@ int Gtk3Gui_WLineEdit_Setup(GWEN_WIDGET *w) {
   const char *s;
   uint32_t flags;
   GWEN_WIDGET *wParent;
-  gulong deleted_text_handler_id;
-  gulong inserted_text_handler_id;
   gboolean text_is_visible;
 
   flags=GWEN_Widget_GetFlags(w);
@@ -206,15 +204,15 @@ int Gtk3Gui_WLineEdit_Setup(GWEN_WIDGET *w) {
   GWEN_Widget_SetSetCharPropertyFn(w, Gtk3Gui_WLineEdit_SetCharProperty);
   GWEN_Widget_SetGetCharPropertyFn(w, Gtk3Gui_WLineEdit_GetCharProperty);
 
-  deleted_text_handler_id=g_signal_connect(gtk_entry_get_buffer(GTK_ENTRY(g)),
-                          "deleted-text",
-                          G_CALLBACK (Gtk3Gui_WLineEdit_Deleted_text_handler),
-                          w);
+  g_signal_connect(gtk_entry_get_buffer(GTK_ENTRY(g)),
+                   "deleted-text",
+                   G_CALLBACK (Gtk3Gui_WLineEdit_Deleted_text_handler),
+                   w);
 
-  inserted_text_handler_id=g_signal_connect(gtk_entry_get_buffer(GTK_ENTRY(g)),
-                           "inserted-text",
-                           G_CALLBACK (Gtk3Gui_WLineEdit_Inserted_text_handler),
-                           w);
+  g_signal_connect(gtk_entry_get_buffer(GTK_ENTRY(g)),
+                   "inserted-text",
+                   G_CALLBACK (Gtk3Gui_WLineEdit_Inserted_text_handler),
+                   w);
 
   if (wParent)
     GWEN_Widget_AddChildGuiWidget(wParent, w);

--- a/gui/gtk3/w_listbox.c
+++ b/gui/gtk3/w_listbox.c
@@ -252,7 +252,6 @@ int Gtk3Gui_WListBox_SetCharProperty(GWEN_WIDGET *w,
       GType types[W_LISTBOX_MAX_TYPES];
       GtkListStore *sto;
       int i;
-      const char *s;
       GtkTreeViewColumn *col;
       char *vcopy;
       char *p;
@@ -262,7 +261,6 @@ int Gtk3Gui_WListBox_SetCharProperty(GWEN_WIDGET *w,
       for (i=0; i<cols; i++)
         types[i]=G_TYPE_STRING;
       sto=gtk_list_store_newv(cols, types);
-      s=value;
 
       /* clear current headers in tree view */
       while( (col=gtk_tree_view_get_column(GTK_TREE_VIEW(g), 0)) )
@@ -497,11 +495,8 @@ static void Gtk3Gui_WListBox_CursorChanged_handler(GtkTreeView *g, gpointer data
 int Gtk3Gui_WListBox_Setup(GWEN_WIDGET *w) {
   GtkWidget *g;
   GtkWidget *gScroll;
-  uint32_t flags;
   GWEN_WIDGET *wParent;
-  gulong changed_handler_id;
 
-  flags=GWEN_Widget_GetFlags(w);
   wParent=GWEN_Widget_Tree_GetParent(w);
 
   gScroll=gtk_scrolled_window_new(NULL, NULL);
@@ -526,10 +521,10 @@ int Gtk3Gui_WListBox_Setup(GWEN_WIDGET *w) {
   GWEN_Widget_SetSetCharPropertyFn(w, Gtk3Gui_WListBox_SetCharProperty);
   GWEN_Widget_SetGetCharPropertyFn(w, Gtk3Gui_WListBox_GetCharProperty);
 
-  changed_handler_id=g_signal_connect(g,
-                                      "cursor-changed",
-                                      G_CALLBACK (Gtk3Gui_WListBox_CursorChanged_handler),
-                                      w);
+  g_signal_connect(g,
+                   "cursor-changed",
+                   G_CALLBACK (Gtk3Gui_WListBox_CursorChanged_handler),
+                   w);
 
   if (wParent)
     GWEN_Widget_AddChildGuiWidget(wParent, w);

--- a/gui/gtk3/w_progressbar.c
+++ b/gui/gtk3/w_progressbar.c
@@ -209,17 +209,13 @@ static void GWENHYWFAR_CB Gtk3Gui_WProgressBar_FreeData(void *bp, void *p) {
 
 int Gtk3Gui_WProgressBar_Setup(GWEN_WIDGET *w) {
   GtkWidget *g;
-  const char *s;
-  uint32_t flags;
   GWEN_WIDGET *wParent;
   W_PROGRESSBAR *xw;
 
   GWEN_NEW_OBJECT(W_PROGRESSBAR, xw);
   GWEN_INHERIT_SETDATA(GWEN_WIDGET, W_PROGRESSBAR, w, xw, Gtk3Gui_WProgressBar_FreeData);
 
-  flags=GWEN_Widget_GetFlags(w);
   wParent=GWEN_Widget_Tree_GetParent(w);
-  s=GWEN_Widget_GetText(w, 0);
 
   g=gtk_progress_bar_new();
   GWEN_Widget_SetImplData(w, GTK3_DIALOG_WIDGET_REAL, (void*) g);

--- a/gui/gtk3/w_pushbutton.c
+++ b/gui/gtk3/w_pushbutton.c
@@ -156,11 +156,8 @@ static void Gtk3Gui_WPushButton_Clicked_handler(GtkButton *button, gpointer data
 int Gtk3Gui_WPushButton_Setup(GWEN_WIDGET *w) {
   GtkWidget *g;
   const char *s;
-  uint32_t flags;
   GWEN_WIDGET *wParent;
-  gulong clicked_handler_id;
 
-  flags=GWEN_Widget_GetFlags(w);
   wParent=GWEN_Widget_Tree_GetParent(w);
   s=GWEN_Widget_GetText(w, 0);
 
@@ -204,10 +201,10 @@ int Gtk3Gui_WPushButton_Setup(GWEN_WIDGET *w) {
   GWEN_Widget_SetSetCharPropertyFn(w, Gtk3Gui_WPushButton_SetCharProperty);
   GWEN_Widget_SetGetCharPropertyFn(w, Gtk3Gui_WPushButton_GetCharProperty);
 
-  clicked_handler_id=g_signal_connect(g,
-                                      "clicked",
-                                      G_CALLBACK (Gtk3Gui_WPushButton_Clicked_handler),
-                                      w);
+  g_signal_connect(g,
+                   "clicked",
+                   G_CALLBACK (Gtk3Gui_WPushButton_Clicked_handler),
+                   w);
 
   if (wParent)
     GWEN_Widget_AddChildGuiWidget(wParent, w);

--- a/gui/gtk3/w_radiobutton.c
+++ b/gui/gtk3/w_radiobutton.c
@@ -162,13 +162,11 @@ static void Gtk3Gui_WRadioButton_Toggled_handler(GtkButton *button, gpointer dat
 int Gtk3Gui_WRadioButton_Setup(GWEN_WIDGET *w) {
   GtkWidget *g;
   const char *s;
-  uint32_t flags;
   GWEN_WIDGET *wParent;
   GWEN_WIDGET *wT;
   gulong toggled_handler_id;
   int groupId;
 
-  flags=GWEN_Widget_GetFlags(w);
   wParent=GWEN_Widget_Tree_GetParent(w);
   groupId=GWEN_Widget_GetGroupId(w);
 
@@ -208,10 +206,10 @@ int Gtk3Gui_WRadioButton_Setup(GWEN_WIDGET *w) {
   GWEN_Widget_SetSetCharPropertyFn(w, Gtk3Gui_WRadioButton_SetCharProperty);
   GWEN_Widget_SetGetCharPropertyFn(w, Gtk3Gui_WRadioButton_GetCharProperty);
 
-  toggled_handler_id=g_signal_connect(g,
-                                      "toggled",
-                                      G_CALLBACK (Gtk3Gui_WRadioButton_Toggled_handler),
-                                      w);
+  g_signal_connect(g,
+                   "toggled",
+                   G_CALLBACK (Gtk3Gui_WRadioButton_Toggled_handler),
+                   w);
 
   if (wParent)
     GWEN_Widget_AddChildGuiWidget(wParent, w);

--- a/gui/gtk3/w_scrollarea.c
+++ b/gui/gtk3/w_scrollarea.c
@@ -163,10 +163,8 @@ int Gtk3Gui_WScrollArea_AddChildGuiWidget(GWEN_WIDGET *w, GWEN_WIDGET *wChild) {
 int Gtk3Gui_WScrollArea_Setup(GWEN_WIDGET *w) {
   GtkWidget *g;
   GtkWidget *gContent;
-  uint32_t flags;
   GWEN_WIDGET *wParent;
 
-  flags=GWEN_Widget_GetFlags(w);
   wParent=GWEN_Widget_Tree_GetParent(w);
 
   /* create widget */

--- a/gui/gtk3/w_spinbox.c
+++ b/gui/gtk3/w_spinbox.c
@@ -178,18 +178,13 @@ static void Gtk3Gui_WSpinBox_Changed_handler(GtkAdjustment *adjustment, gpointer
 
 int Gtk3Gui_WSpinBox_Setup(GWEN_WIDGET *w) {
   GtkWidget *g;
-  const char *s;
-  uint32_t flags;
   GWEN_WIDGET *wParent;
   W_SPINBOX *xw;
-  gulong changed_handler_id;
 
   GWEN_NEW_OBJECT(W_SPINBOX, xw);
   GWEN_INHERIT_SETDATA(GWEN_WIDGET, W_SPINBOX, w, xw, Gtk3Gui_WSpinBox_FreeData);
 
-  flags=GWEN_Widget_GetFlags(w);
   wParent=GWEN_Widget_Tree_GetParent(w);
-  s=GWEN_Widget_GetText(w, 0);
 
   xw->adjustment=GTK_ADJUSTMENT(gtk_adjustment_new(0.0, 0.0, 100.0, 1.0, 5.0, 5.0));
   g=gtk_spin_button_new(xw->adjustment, 1.0, 0);
@@ -201,10 +196,10 @@ int Gtk3Gui_WSpinBox_Setup(GWEN_WIDGET *w) {
   GWEN_Widget_SetSetCharPropertyFn(w, Gtk3Gui_WSpinBox_SetCharProperty);
   GWEN_Widget_SetGetCharPropertyFn(w, Gtk3Gui_WSpinBox_GetCharProperty);
 
-  changed_handler_id=g_signal_connect(g,
-                                      "value-changed",
-                                      G_CALLBACK (Gtk3Gui_WSpinBox_Changed_handler),
-                                      w);
+  g_signal_connect(g,
+                   "value-changed",
+                   G_CALLBACK (Gtk3Gui_WSpinBox_Changed_handler),
+                   w);
 
   if (wParent)
     GWEN_Widget_AddChildGuiWidget(wParent, w);

--- a/gui/gtk3/w_stack.c
+++ b/gui/gtk3/w_stack.c
@@ -147,10 +147,8 @@ int Gtk3Gui_WStack_AddChildGuiWidget(GWEN_WIDGET *w, GWEN_WIDGET *wChild) {
 
 int Gtk3Gui_WStack_Setup(GWEN_WIDGET *w) {
   GtkWidget *g;
-  uint32_t flags;
   GWEN_WIDGET *wParent;
 
-  flags=GWEN_Widget_GetFlags(w);
   wParent=GWEN_Widget_Tree_GetParent(w);
 
   g=gtk_notebook_new();

--- a/gui/gtk3/w_tabbook.c
+++ b/gui/gtk3/w_tabbook.c
@@ -141,10 +141,8 @@ int Gtk3Gui_WTabBook_AddChildGuiWidget(GWEN_WIDGET *w, GWEN_WIDGET *wChild) {
 
 int Gtk3Gui_WTabBook_Setup(GWEN_WIDGET *w) {
   GtkWidget *g;
-  uint32_t flags;
   GWEN_WIDGET *wParent;
 
-  flags=GWEN_Widget_GetFlags(w);
   wParent=GWEN_Widget_Tree_GetParent(w);
 
   g=gtk_notebook_new();

--- a/gui/gtk3/w_textbrowser.c
+++ b/gui/gtk3/w_textbrowser.c
@@ -193,10 +193,8 @@ int Gtk3Gui_WTextBrowser_Setup(GWEN_WIDGET *w) {
   GtkWidget *gs;
   GtkWidget *g;
   const char *s;
-  uint32_t flags;
   GWEN_WIDGET *wParent;
 
-  flags=GWEN_Widget_GetFlags(w);
   wParent=GWEN_Widget_Tree_GetParent(w);
   s=GWEN_Widget_GetText(w, 0);
 

--- a/gui/gtk3/w_textedit.c
+++ b/gui/gtk3/w_textedit.c
@@ -187,11 +187,8 @@ static void Gtk3Gui_WTextEdit_Changed_handler(GtkTextBuffer *buffer, gpointer da
 int Gtk3Gui_WTextEdit_Setup(GWEN_WIDGET *w) {
   GtkWidget *g;
   const char *s;
-  uint32_t flags;
   GWEN_WIDGET *wParent;
-  gulong changed_handler_id;
 
-  flags=GWEN_Widget_GetFlags(w);
   wParent=GWEN_Widget_Tree_GetParent(w);
   s=GWEN_Widget_GetText(w, 0);
 
@@ -208,7 +205,7 @@ int Gtk3Gui_WTextEdit_Setup(GWEN_WIDGET *w) {
   GWEN_Widget_SetSetCharPropertyFn(w, Gtk3Gui_WTextEdit_SetCharProperty);
   GWEN_Widget_SetGetCharPropertyFn(w, Gtk3Gui_WTextEdit_GetCharProperty);
 
-  changed_handler_id=g_signal_connect(gtk_text_view_get_buffer(GTK_TEXT_VIEW(g)),
+  g_signal_connect(gtk_text_view_get_buffer(GTK_TEXT_VIEW(g)),
                                       "changed",
                                       G_CALLBACK (Gtk3Gui_WTextEdit_Changed_handler),
                                       w);

--- a/gui/gtk3/w_vlayout.c
+++ b/gui/gtk3/w_vlayout.c
@@ -137,10 +137,8 @@ int Gtk3Gui_WVLayout_AddChildGuiWidget(GWEN_WIDGET *w, GWEN_WIDGET *wChild) {
 
 int Gtk3Gui_WVLayout_Setup(GWEN_WIDGET *w) {
   GtkWidget *g;
-  uint32_t flags;
   GWEN_WIDGET *wParent;
 
-  flags=GWEN_Widget_GetFlags(w);
   wParent=GWEN_Widget_Tree_GetParent(w);
 
   g=gtk_box_new(GTK_ORIENTATION_VERTICAL,

--- a/gui/gtk3/w_vline.c
+++ b/gui/gtk3/w_vline.c
@@ -76,10 +76,8 @@ int Gtk3Gui_WVLine_GetIntProperty(GWEN_WIDGET *w,
 
 int Gtk3Gui_WVLine_Setup(GWEN_WIDGET *w) {
   GtkWidget *g;
-  uint32_t flags;
   GWEN_WIDGET *wParent;
 
-  flags=GWEN_Widget_GetFlags(w);
   wParent=GWEN_Widget_Tree_GetParent(w);
 
   g=gtk_separator_new(GTK_ORIENTATION_VERTICAL);

--- a/gui/gtk3/w_vspacer.c
+++ b/gui/gtk3/w_vspacer.c
@@ -76,10 +76,8 @@ int Gtk3Gui_WVSpacer_GetIntProperty(GWEN_WIDGET *w,
 
 int Gtk3Gui_WVSpacer_Setup(GWEN_WIDGET *w) {
   GtkWidget *g;
-  uint32_t flags;
   GWEN_WIDGET *wParent;
 
-  flags=GWEN_Widget_GetFlags(w);
   wParent=GWEN_Widget_Tree_GetParent(w);
 
   g=gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);


### PR DESCRIPTION
I recently ran the clang static analyzer (via Xcode) on GnuCash. We're carrying a copy of the gwen gtk3 gui to support distros that don't yet have 4.20 and it picked up a few unused variables, which I removed. This PR are those changes applied to gwenhywfar directly.