### PR TITLE
Buil libgwengui-qt5-0.dll as well

### DIFF
--- a/gui/qt5/Makefile.am
+++ b/gui/qt5/Makefile.am
@@ -69,6 +69,7 @@ libtest_SOURCES=libtest.cpp
 libtest_LDADD=libgwengui-qt5.la $(top_builddir)/src/$(gwenhywfar_internal_libname) $(QT_LIBS) \
   $(top_builddir)/gui/cpp/libgwengui-cpp.la \
   $(builddir)/../testdialogs/libgwengui-test.la
+libgwengui_qt5_la_LDFLAGS = -no-undefined
 
 SUFFIXES = .ui .ui.hpp .ui.cpp .moc
 


### PR DESCRIPTION
gwenhywfar/gui/cpp/Makefile.am contains this line and as a result
libgwengui-cpp-0.dll is created

gwenhywfar/gui/cpp/Makefile.am doesn't contain thi line and as a result
only libgwengui-qt5.a is created

This patch changes it so that libgwengui-qt5-0.dll is created as well on
MSYS2 builds.