### PR TITLE
Use pkgconf for libgcrypt build flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -665,7 +665,6 @@ fi
 #
 # check for libgcrypt
 #
-NEED_LIBGCRYPT_API=1
 NEED_LIBGCRYPT_VERSION=1.2.0
 AC_DEFINE_UNQUOTED(NEED_LIBGCRYPT_VERSION, "$NEED_LIBGCRYPT_VERSION",
                                      [Required version of Libgcrypt])
@@ -677,12 +676,12 @@ case "$OS_TYPE" in
     AC_SUBST(LIBGCRYPT_LIBS)
     ;;
   *)
-    AM_PATH_LIBGCRYPT("$NEED_LIBGCRYPT_API:$NEED_LIBGCRYPT_VERSION",
+    PKG_CHECK_MODULES([LIBGCRYPT], [libgcrypt >= $NEED_LIBGCRYPT_VERSION],
                       [have_gcrypt="yes"], [have_gcrypt="no"])
     if test "$have_gcrypt" != "yes"; then
       AC_MSG_ERROR([
     **** Libgcrypt is required for Gwenhywfar. Please install it (including devel packages)
-    **** (at least version $NEED_LIBGCRYPT_VERSION using API $NEED_LIBGCRYPT_API is required.)])
+    **** (at least version $NEED_LIBGCRYPT_VERSION is required.)])
     fi
     ;;
 esac


### PR DESCRIPTION
On some build systems the old automake macro AM_PATH_LIBGCRYPTf doesn't work because the binary libgcrypt-config no longer exists. As a libgcrypt.pc file is available, let's switch to this more contemporary approach to determine the libgcrypt build flags.

Tested on Arch Linux with libgcrypt 1.11.0